### PR TITLE
paypal-rest-sdk 1.5.2

### DIFF
--- a/with.shoppingcart/package.json
+++ b/with.shoppingcart/package.json
@@ -47,7 +47,7 @@
     "localizr": "~0.1.0",
     "method-override": "^2.1.3",
     "mongoose": "~3.8.8",
-    "paypal-rest-sdk": "^0.6.4",
+    "paypal-rest-sdk": "^1.5.2",
     "requirejs": "~2.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Update paypal-rest-sdk version to 1.5.2. Need for work with node.js 0.12.x